### PR TITLE
Amj/scripts status signals import

### DIFF
--- a/lib/servers/abstractservers/script_scanner/script_status.py
+++ b/lib/servers/abstractservers/script_scanner/script_status.py
@@ -1,5 +1,5 @@
 from twisted.internet.defer import inlineCallbacks, DeferredLock, Deferred
-from signals import Signals
+
 
 class script_semaphore(object):
     '''class for storing information about runtime behavior script'''
@@ -13,19 +13,19 @@ class script_semaphore(object):
         self.should_stop = False
         self.ident = ident
         self.signals = signals
-        
+
     def get_progress(self):
         return (self.status, self.percentage_complete)
-    
+
     def set_percentage(self, perc):
         if not 0.0 <= perc <= 100.0: raise Exception ("Incorrect Percentage of Completion")
         self.percentage_complete = perc
         self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
-    
+
     def launch_confirmed(self):
         self.status = 'Running'
         self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
-        
+
     @inlineCallbacks
     def pause(self):
         '''
@@ -60,7 +60,7 @@ class script_semaphore(object):
         #if was paused, unpause:
         if self.pause_lock.locked:
             self.pause_lock.release()
-    
+
     def set_pausing(self, should_pause):
         '''if asking to pause, returns a deferred which is fired when sciprt actually paused'''
         if should_pause:
@@ -83,13 +83,13 @@ class script_semaphore(object):
 #            print 'releasing the lock!'
             self.pause_lock.release()
         return request
-            
+
     def stop_confirmed(self):
         self.should_stop = False
         self.status = 'Stopped'
         self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
         self.signals.on_running_script_stopped(self.ident)
-    
+
     def finish_confirmed(self):
         #call back all pause requests
         for request_list in [self.pause_requests, self.continue_requests]:
@@ -101,7 +101,7 @@ class script_semaphore(object):
             self.status = 'Finished'
             self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
         self.signals.on_running_script_finished(self.ident)
-    
+
     def error_finish_confirmed(self, error):
         self.status = 'Error'
         self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))

--- a/lib/servers/abstractservers/script_scanner/script_status.py
+++ b/lib/servers/abstractservers/script_scanner/script_status.py
@@ -18,13 +18,16 @@ class script_semaphore(object):
         return (self.status, self.percentage_complete)
 
     def set_percentage(self, perc):
-        if not 0.0 <= perc <= 100.0: raise Exception ("Incorrect Percentage of Completion")
+        if not 0.0 <= perc <= 100.0:
+            raise Exception("Incorrect Percentage of Completion")
         self.percentage_complete = perc
-        self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
+        self.signals.on_running_new_status((self.ident, self.status,
+                                            self.percentage_complete))
 
     def launch_confirmed(self):
         self.status = 'Running'
-        self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
+        self.signals.on_running_new_status((self.ident, self.status,
+                                            self.percentage_complete))
 
     @inlineCallbacks
     def pause(self):
@@ -33,9 +36,11 @@ class script_semaphore(object):
         '''
         if self.pause_lock.locked:
             self.status = 'Paused'
-            self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
+            self.signals.on_running_new_status((self.ident, self.status,
+                                                self.percentage_complete))
+
             self.signals.on_running_script_paused((self.ident, True))
-            #call back all pause requests
+            # call back all pause requests
             while self.pause_requests:
                 request = self.pause_requests.pop()
 #                print 'called back pause requests', request
@@ -46,9 +51,11 @@ class script_semaphore(object):
 #        print 'script proceeding'
         if self.status == 'Paused':
             self.status = 'Running'
-            self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
+            self.signals.on_running_new_status((self.ident, self.status,
+                                                self.percentage_complete))
+
             self.signals.on_running_script_paused((self.ident, False))
-            #call back all continue requests
+            # call back all continue requests
             while self.continue_requests:
                 request = self.continue_requests.pop()
                 request.callback(True)
@@ -56,28 +63,34 @@ class script_semaphore(object):
     def set_stopping(self):
         self.should_stop = True
         self.status = 'Stopping'
-        self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
-        #if was paused, unpause:
+        self.signals.on_running_new_status((self.ident, self.status,
+                                            self.percentage_complete))
+
+        # if was paused, unpause:
         if self.pause_lock.locked:
             self.pause_lock.release()
 
     def set_pausing(self, should_pause):
-        '''if asking to pause, returns a deferred which is fired when sciprt actually paused'''
+        '''if asking to pause, returns a deferred which is fired when sciprt
+        actually paused'''
         if should_pause:
             request = Deferred()
             print 'made request', request
             self.pause_requests.append(request)
             if not self.pause_lock.locked:
-                #if not already paused
-                self.pause_lock.acquire()#immediately returns a deferred that we don't use
+                # if not already paused
+                # immediately returns a deferred that we don't use
+                self.pause_lock.acquire()
                 self.status = 'Pausing'
-                self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
+                self.signals.on_running_new_status((self.ident, self.status,
+                                                    self.percentage_complete))
+
 #                print 'acquired pause', request
             else:
                 print 'not acquiring because locked'
         else:
             if not self.pause_lock.locked:
-                raise Exception ("Trying to unpause script that was not paused")
+                raise Exception("Trying to unpause script that was not paused")
             request = Deferred()
             self.continue_requests.append(request)
 #            print 'releasing the lock!'
@@ -87,11 +100,13 @@ class script_semaphore(object):
     def stop_confirmed(self):
         self.should_stop = False
         self.status = 'Stopped'
-        self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
+        self.signals.on_running_new_status((self.ident, self.status,
+                                            self.percentage_complete))
+
         self.signals.on_running_script_stopped(self.ident)
 
     def finish_confirmed(self):
-        #call back all pause requests
+        # call back all pause requests
         for request_list in [self.pause_requests, self.continue_requests]:
             while(request_list):
                 request = request_list.pop()
@@ -99,10 +114,14 @@ class script_semaphore(object):
         if not self.status == 'Stopped':
             self.percentage_complete = 100.0
             self.status = 'Finished'
-            self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
+            self.signals.on_running_new_status((self.ident, self.status,
+                                                self.percentage_complete))
+
         self.signals.on_running_script_finished(self.ident)
 
     def error_finish_confirmed(self, error):
         self.status = 'Error'
-        self.signals.on_running_new_status((self.ident, self.status, self.percentage_complete))
+        self.signals.on_running_new_status((self.ident, self.status,
+                                            self.percentage_complete))
+
         self.signals.on_running_script_finished_error((self.ident, error))

--- a/lib/servers/abstractservers/script_scanner/script_status.py
+++ b/lib/servers/abstractservers/script_scanner/script_status.py
@@ -43,12 +43,9 @@ class script_semaphore(object):
             # call back all pause requests
             while self.pause_requests:
                 request = self.pause_requests.pop()
-#                print 'called back pause requests', request
                 request.callback(True)
-#        print 'script checking on whether should pause'
         yield self.pause_lock.acquire()
         self.pause_lock.release()
-#        print 'script proceeding'
         if self.status == 'Paused':
             self.status = 'Running'
             self.signals.on_running_new_status((self.ident, self.status,
@@ -85,7 +82,6 @@ class script_semaphore(object):
                 self.signals.on_running_new_status((self.ident, self.status,
                                                     self.percentage_complete))
 
-#                print 'acquired pause', request
             else:
                 print 'not acquiring because locked'
         else:
@@ -93,7 +89,6 @@ class script_semaphore(object):
                 raise Exception("Trying to unpause script that was not paused")
             request = Deferred()
             self.continue_requests.append(request)
-#            print 'releasing the lock!'
             self.pause_lock.release()
         return request
 


### PR DESCRIPTION
review: @aransfor , @gregllong 

The old Signals (https://github.com/CampbellGroup/common/blob/master/lib/servers/abstractservers/script_scanner/script_signals_server.py) was imported and unused here.

Cleaned up script_status.py