### PR TITLE
Change the server name to make it distinct from the original data_vault.

### DIFF
--- a/lib/servers/datavault/data_vault_cg.py
+++ b/lib/servers/datavault/data_vault_cg.py
@@ -17,10 +17,10 @@
 """
 ### BEGIN NODE INFO
 [info]
-name = Data Vault
+name = Data Vault cg
 version = 2.4
 description =
-instancename = Data Vault
+instancename = Data Vault cg
 
 [startup]
 cmdline = %PYTHON% %FILE%
@@ -855,14 +855,14 @@ if useNumpy:
 
 
 class DataVault( LabradServer ):
-    name = 'Data Vault'
+    name = 'Data Vault cg'
 
     @inlineCallbacks
     def initServer( self ):
         # load configuration info from registry
         global DATADIR
         try:
-            path = ['', 'Servers', self.name, 'Repository']
+            path = ['', 'Servers', 'Data Vault', 'Repository']
             nodename = util.getNodeName()
             reg = self.client.registry
             try:


### PR DESCRIPTION
Hard-coded the repository path from self.name to "Data Vault."

Review: @aransfor , @gregllong , @theoriginaljuice 

I expect this PR to take a while to implement.  I'm not sure about the hard-coded name change for the data vault path.

The intent here is not to have conflicts with the original Martinis group data vault.

I recommend branching your experiment repository, something like data_vault_cg, and try to get your code working with this PR.

