### PR TITLE
pyserial v3.0.1 uses setter and getter for baudrate.  Changed the ser…

### DIFF
--- a/lib/servers/serialserver/serial_server.py
+++ b/lib/servers/serialserver/serial_server.py
@@ -153,8 +153,8 @@ class SerialServer(LabradServer):
         if data is None:
             return long(ser.baudrate)
         else:
-            baudrate = ser.baudrate = data
-            return long(baudrate)
+            ser.baudrate = data
+            return long(ser.baudrate)
 
     @setting(21, 'Bytesize',
                  data=[': List bytesizes',

--- a/lib/servers/serialserver/serial_server.py
+++ b/lib/servers/serialserver/serial_server.py
@@ -151,10 +151,10 @@ class SerialServer(LabradServer):
         """Sets the baudrate."""
         ser = self.getPort(c)
         if data is None:
-            return long(ser.getBaudrate())
-        else: 
-            ser.setBaudrate(data)
-            return long(ser.getBaudrate())
+            return long(ser.baudrate)
+        else:
+            baudrate = ser.baudrate = data
+            return long(baudrate)
 
 
     @setting(21, 'Bytesize',

--- a/lib/servers/serialserver/serial_server.py
+++ b/lib/servers/serialserver/serial_server.py
@@ -30,7 +30,6 @@ message = 987654321
 timeout = 20
 ### END NODE INFO
 """
-
 from labrad import types as T, util
 from labrad.errors import Error
 from labrad.server import LabradServer, setting
@@ -164,11 +163,11 @@ class SerialServer(LabradServer):
     def bytesize(self, c, data=None):
         """Sets the bytesize."""
         ser = self.getPort(c)
-        bsizes = ser.BYTESIZES
+        bytesizes = ser.BYTESIZES
         if data is None:
-            return bsizes
+            return bytesizes
         else:
-            if data in bsizes:
+            if data in bytesizes:
                 ser.bytesize = data
             return long(ser.bytesize)
 
@@ -180,12 +179,12 @@ class SerialServer(LabradServer):
     def parity(self, c, data=None):
         """Sets the parity."""
         ser = self.getPort(c)
-        bsizes =  ser.PARITIES
+        parities =  ser.PARITIES
         if data is None:
-            return bsizes
+            return parities
         else:
             data = data.upper()
-            if data in bsizes:
+            if data in parities:
                 ser.parity = data
             return ser.parity
 
@@ -197,11 +196,11 @@ class SerialServer(LabradServer):
     def stopbits(self, c, data=None):
         """Sets the number of stop bits."""
         ser = self.getPort(c)
-        bsizes =  ser.STOPBITS
+        stopbits =  ser.STOPBITS
         if data is None:
-            return bsizes
+            return stopbits
         else:
-            if data in bsizes:
+            if data in stopbits:
                 ser.stopbits = data
             return long(ser.stopbits)
 

--- a/lib/servers/serialserver/serial_server.py
+++ b/lib/servers/serialserver/serial_server.py
@@ -164,13 +164,13 @@ class SerialServer(LabradServer):
     def bytesize(self, c, data=None):
         """Sets the bytesize."""
         ser = self.getPort(c)
-        bsizes = [long(x[1]) for x in ser.getSupportedByteSizes()]
+        bsizes = ser.BYTESIZES
         if data is None:
             return bsizes
         else:
             if data in bsizes:
-                ser.setByteSize(data)
-            return long(ser.getByteSize())
+                ser.bytesize = data
+            return long(ser.bytesize)
 
     @setting(22, 'Parity',
                  data=[': List parities',
@@ -180,14 +180,14 @@ class SerialServer(LabradServer):
     def parity(self, c, data=None):
         """Sets the parity."""
         ser = self.getPort(c)
-        bsizes = [x[1] for x in ser.getSupportedParities()]
+        bsizes =  ser.PARITIES
         if data is None:
             return bsizes
         else:
             data = data.upper()
             if data in bsizes:
-                ser.setParity(data)
-            return ser.getParity()
+                ser.parity = data
+            return ser.parity
 
     @setting(23, 'Stopbits',
                  data=[': List stopbits',
@@ -197,13 +197,13 @@ class SerialServer(LabradServer):
     def stopbits(self, c, data=None):
         """Sets the number of stop bits."""
         ser = self.getPort(c)
-        bsizes = [long(x[1]) for x in ser.getSupportedStopbits()]
+        bsizes =  ser.STOPBITS
         if data is None:
             return bsizes
         else:
             if data in bsizes:
-                ser.setStopbits(data)
-            return long(ser.getStopbits())
+                ser.stopbits = data
+            return long(ser.stopbits)
 
     @setting(25, 'Timeout',
                  data=[': Return immediately',
@@ -219,14 +219,14 @@ class SerialServer(LabradServer):
     def RTS(self, c, data):
         """Sets the state of the RTS line."""
         ser = self.getPort(c)
-        ser.setRTS(int(data))
+        ser.rts = int(data)
         return data
 
     @setting(31, 'DTR', data=['b'], returns=['b'])
     def DTR(self, c, data):
         """Sets the state of the DTR line."""
         ser = self.getPort(c)
-        ser.setDTR(int(data))
+        ser.dtr = int(data)
         return data
 
     @setting(40, 'Write',

--- a/lib/servers/serialserver/serial_server.py
+++ b/lib/servers/serialserver/serial_server.py
@@ -44,13 +44,16 @@ from serial.serialutil import SerialException
 
 from time import sleep
 
+
 class NoPortSelectedError(Error):
     """Please open a port first."""
     code = 1
 
+
 class NoPortsAvailableError(Error):
     """No serial ports are available."""
     code = 3
+
 
 class SerialServer(LabradServer):
     """Provides access to a computer's serial (COM) ports."""
@@ -60,8 +63,8 @@ class SerialServer(LabradServer):
         print 'Searching for COM ports:'
         self.SerialPorts = []
         ports = list_ports.comports()
-        for name,description,hardware in ports:
-            #make sure the discovered ports can be opened
+        for name, description, hardware in ports:
+            # make sure the discovered ports can be opened
             try:
                 ser = Serial(name)
                 ser.close()
@@ -83,7 +86,6 @@ class SerialServer(LabradServer):
         except:
             raise NoPortSelectedError()
 
-
     @setting(1, 'List Serial Ports',
                 returns=['*s: List of serial ports'])
     def list_serial_ports(self, c):
@@ -93,7 +95,6 @@ class SerialServer(LabradServer):
         This list contains all ports installed on the computer,
         including ones that are already in use by other programs."""
         return self.SerialPorts
-
 
     @setting(10, 'Open',
                  port=[': Open the first available port',
@@ -124,7 +125,6 @@ class SerialServer(LabradServer):
                     raise Error(code=2, msg=e.message)
         return c['PortObject'].portstr
 
-
     @setting(11, 'Close', returns=[''])
     def close(self, c):
         """Closes the current serial port."""
@@ -133,19 +133,19 @@ class SerialServer(LabradServer):
             del c['PortObject']
 
     @setting(12, 'flushInput', returns=[''])
-    def flushinput(self,c):
+    def flushinput(self, c):
         """Flushes the Input Buffer of the current serial port"""
         ser = self.getPort(c)
         ser.flushInput()
 
     @setting(13, 'flushOutput', returns=[''])
-    def flushoutput(self,c):
+    def flushoutput(self, c):
         """Flushes the Output Buffer of the current serial port"""
         ser = self.getPort(c)
         ser.flushOutput()
 
     @setting(20, 'Baudrate',
-                 data=[': Selected baudrate','i: Set baudrate'],
+                 data=[': Selected baudrate', 'i: Set baudrate'],
                  returns=['i: Selected baudrate'])
     def baudrate(self, c, data=None):
         """Sets the baudrate."""
@@ -155,7 +155,6 @@ class SerialServer(LabradServer):
         else:
             baudrate = ser.baudrate = data
             return long(baudrate)
-
 
     @setting(21, 'Bytesize',
                  data=[': List bytesizes',
@@ -172,7 +171,6 @@ class SerialServer(LabradServer):
             if data in bsizes:
                 ser.setByteSize(data)
             return long(ser.getByteSize())
-
 
     @setting(22, 'Parity',
                  data=[': List parities',
@@ -191,7 +189,6 @@ class SerialServer(LabradServer):
                 ser.setParity(data)
             return ser.getParity()
 
-
     @setting(23, 'Stopbits',
                  data=[': List stopbits',
                        'w: Set stopbits (0: query current)'],
@@ -208,17 +205,15 @@ class SerialServer(LabradServer):
                 ser.setStopbits(data)
             return long(ser.getStopbits())
 
-
     @setting(25, 'Timeout',
                  data=[': Return immediately',
                        'v[s]: Timeout to use (max: 5min)'],
                  returns=['v[s]: Timeout being used (0 for immediate return)'])
-    def timeout(self, c, data=T.Value(0,'s')):
+    def timeout(self, c, data=T.Value(0, 's')):
         """Sets a timeout for read operations."""
         ser = self.getPort(c)
         c['Timeout'] = min(data['s'], 300)
         return T.Value(c['Timeout'], 's')
-
 
     @setting(30, 'RTS', data=['b'], returns=['b'])
     def RTS(self, c, data):
@@ -227,14 +222,12 @@ class SerialServer(LabradServer):
         ser.setRTS(int(data))
         return data
 
-
     @setting(31, 'DTR', data=['b'], returns=['b'])
     def DTR(self, c, data):
         """Sets the state of the DTR line."""
         ser = self.getPort(c)
         ser.setDTR(int(data))
         return data
-
 
     @setting(40, 'Write',
                  data=['s: Data to send',
@@ -244,23 +237,22 @@ class SerialServer(LabradServer):
         """Sends data over the port."""
         ser = self.getPort(c)
         if isinstance(data, list):
-            data = ''.join(chr(x&255) for x in data)
+            data = ''.join(chr(x & 255) for x in data)
         ser.write(data)
         return long(len(data))
 
-
     @setting(41, 'Write Line', data=['s: Data to send'],
-                               returns=['w: Bytes sent'])
+             returns=['w: Bytes sent'])
     def write_line(self, c, data):
         """Sends data over the port appending CR LF."""
         ser = self.getPort(c)
         ser.write(data + '\r\n')
         return long(len(data)+2)
 
-
     @inlineCallbacks
     def deferredRead(self, ser, timeout, count=1):
         killit = False
+
         def doRead(count):
             d = ''
             while not killit:
@@ -277,7 +269,6 @@ class SerialServer(LabradServer):
             r = ser.read(count)
 
         returnValue(r)
-
 
     @inlineCallbacks
     def readSome(self, c, count=0):
@@ -302,14 +293,12 @@ class SerialServer(LabradServer):
             recd += r
         returnValue(recd)
 
-
     @setting(50, 'Read', count=[': Read all bytes in buffer',
                                 'w: Read this many bytes'],
-                         returns=['s: Received data'])
+             returns=['s: Received data'])
     def read(self, c, count=0):
         """Read data from the port."""
         return self.readSome(c, count)
-
 
     @setting(51, 'Read as Words',
                  data=[': Read all bytes in buffer',
@@ -320,13 +309,13 @@ class SerialServer(LabradServer):
         ans = yield self.readSome(c, data)
         returnValue([long(ord(x)) for x in ans])
 
-
     @setting(52, 'Read Line',
                  data=[': Read until LF, ignoring CRs',
                        's: Other delimiter to use'],
                  returns=['s: Received data'])
     def read_line(self, c, data=''):
-        """Read data from the port, up to but not including the specified delimiter."""
+        """Read data from the port, up to but not including the specified
+        delimiter."""
         ser = self.getPort(c)
         timeout = c['Timeout']
 

--- a/tests/hardware_dependent/lib/servers/AD9910_DDS_Box/test_DDS_BOX_SERVER.py
+++ b/tests/hardware_dependent/lib/servers/AD9910_DDS_Box/test_DDS_BOX_SERVER.py
@@ -6,23 +6,19 @@ DDS Box 2 on 'COM4'
 
 TODO: Make test code more hardware configuration independent.
 """
-
 from twisted.trial.unittest import TestCase
-
 import labrad
 import labrad.units as _u
 
 
-
 class Test_DDS_BOX_Server(TestCase):
-
     debug = False
 
     def setUp(self):
         """
         Connect to labrad
         """
-        self.cxn = labrad.connect() #host='localhost')
+        self.cxn = labrad.connect() # host='localhost')
 
         self._check_serial_server()
         # Setup default values for the camera
@@ -31,17 +27,12 @@ class Test_DDS_BOX_Server(TestCase):
         # TODO: Check that we need this
         self.server.select_device('COM4')
 
-
-
     def tearDown(self):
         """
         Disconnect from labrad
         """
         # Reset server values back to their default values
-
-
         self.server = None
-
         self.cxn.disconnect()
 
     def _check_serial_server(self):
@@ -49,9 +40,7 @@ class Test_DDS_BOX_Server(TestCase):
         Make sure the serial server is available, as this device
         depends on it.
         """
-
-        self.assert_(hasattr(self.cxn, 'coach_k_serial_server'))
-
+        self.assert_(hasattr(self.cxn, 'coach_k_serial_server_cg'))
 
     def _get_tester(self):
         """
@@ -65,117 +54,72 @@ class Test_DDS_BOX_Server(TestCase):
         self.assert_(hasattr(self.cxn, 'dds_box_server'))
         return self.cxn.dds_box_server
 
-
     def test_echo(self):
         """
         Test that server has basic function echo
         """
-
-        #server = self._get_tester()
         self.assert_(hasattr(self.server, 'echo'))
-
-
 
     def test_name(self):
         """
         Test server name
         """
-        #server = self._get_tester()
-
         out = self.server.name
         exp = 'DDS Box Server'
         self.assertEquals(exp, out)
-
 
     def test_frequency_set(self):
         """
         Test setting the frequency of channel 4
         """
-
         server = self.server
-
         f = _u.WithUnit(100., 'MHz')
-
         server.frequency(4, f)
-
         out = server.frequency(4)
-
         exp = _u.WithUnit(100., 'MHz')
         self.assertEquals(exp, out)
-
 
     def test_channel_state_setFalse(self):
         """
         Set channel_state of channel 4
         """
-
         self.server.channel_state(4, False)
-
         out = self.server.channel_state(4)
-
         exp = False
         self.assertEquals(exp, out)
-
 
     def test_channel_state_setTrue(self):
         """
         Set channel_state of channel 4
         """
-
         self.server.channel_state(4, True)
-
         out = self.server.channel_state(4)
-
         exp = True
         self.assertEquals(exp, out)
-
-
 
     def test_amplitude_setFalse(self):
         """
         Set the amplitude of channel 4
         """
-
         self.server.amplitude(4, False)
         out = self.server.amplitude(4)
-
         exp = False
         self.assertEquals(exp, out)
-
 
     def test_amplitude_dbm_get(self):
         """
         Test amplitude of channel 4
         """
-
         out = self.server.amplitude_dbm(4)
-
         exp = False
         self.assertEquals(exp, out)
-
 
     def test_amplitude_hex_get(self):
         """
         Test amplitude_hex of channel 4
         """
-
         val = 'afd1'
-
         self.server.amplitude_hex(4, val)
         out = self.server.amplitude_hex(4)
-
         exp = val
         self.assertEquals(exp, out)
-
-
-    def test_AmpSetStr_HEX(self):
-        """
-        Test command output
-        """
-
-
-
-
-
-
-


### PR DESCRIPTION
…ial_server accordingly.

Review: @aransfor , @theoriginaljuice , @gregllong 

This requires upgrading pyserial to version 3.0.1.  I looked into this.  The bug came up because of a pyserial dependence that had changed.  I didn't look further down the rabbit hole than here https://github.com/mavlink/mavlink/issues/498.  Currently this works with the eVPump server.  Please try this out on your respect branches.  If possible I would like to get this PR merged into master ASAP (next couple of days).  Let me know if you are going to be particularly busy and won't be able to try this out in the short term.