### PR TITLE
added a method to wavemeterclient such that it checks the config file…

### DIFF
--- a/lib/clients/Multiplexer/multiplexerclient.py
+++ b/lib/clients/Multiplexer/multiplexerclient.py
@@ -72,7 +72,7 @@ class wavemeterclient(QtGui.QWidget):
         screensize = desktop.availableGeometry()
         width = screensize.width()
         height = screensize.height()
-        if (width or height) <= 1080:
+        if (width <=1080 or height <= 1080):
             self.showMaximized()
 
     @inlineCallbacks

--- a/lib/clients/Multiplexer/multiplexerclient.py
+++ b/lib/clients/Multiplexer/multiplexerclient.py
@@ -64,6 +64,12 @@ class wavemeterclient(QtGui.QWidget):
         self.d = {}
         self.wmChannels = {}
         self.connect()
+        self._check_window_size()
+
+    def _check_window_size(self):
+        if hasattr(multiplexer_config, "resize_window"):
+            if multiplexer_config.resize_window is True:
+                self.showMaximized()
 
     @inlineCallbacks
     def connect(self):
@@ -130,9 +136,9 @@ class wavemeterclient(QtGui.QWidget):
             displayPID = self.chaninfo[chan][4]
             dacPort = self.chaninfo[chan][5]
             widget = QCustomWavemeterChannel(chan, wmChannel, dacPort, hint, stretched, displayPID)
-            
+
             if displayPID:
-                try: 
+                try:
                     rails = self.chaninfo[chan][6]
                     widget.PIDindicator.set_rails(rails)
                 except:
@@ -269,7 +275,7 @@ class wavemeterclient(QtGui.QWidget):
         if wmChannel in self.d:
             #self.d[wmChannel].interfAmp.setText('Interferometer Amp\n' + str(value))
             self.d[wmChannel].powermeter.setValue(value)#('Interferometer Amp\n' + str(value))
-    
+
     def setButtonOff(self,wmChannel):
         self.d[wmChannel].lockChannel.setChecked(False)
 

--- a/lib/clients/Multiplexer/multiplexerclient.py
+++ b/lib/clients/Multiplexer/multiplexerclient.py
@@ -70,7 +70,9 @@ class wavemeterclient(QtGui.QWidget):
         """Checks screen size to make sure window fits in the screen. """
         desktop = QtGui.QDesktopWidget()
         screensize = desktop.availableGeometry()
-        if (screensize[0] or screensize[1]) <= 1080:
+        width = screensize.width()
+        height = screensize.height()
+        if (width or height) <= 1080:
             self.showMaximized()
 
     @inlineCallbacks

--- a/lib/clients/Multiplexer/multiplexerclient.py
+++ b/lib/clients/Multiplexer/multiplexerclient.py
@@ -67,6 +67,11 @@ class wavemeterclient(QtGui.QWidget):
         self._check_window_size()
 
     def _check_window_size(self):
+        """Checks from the config file if the window should be resized.
+
+        If the config file does not have the attribute "resize_window", nothing
+        is going to happen so no conflict will be caused.
+        """
         if hasattr(multiplexer_config, "resize_window"):
             if multiplexer_config.resize_window is True:
                 self.showMaximized()

--- a/lib/clients/Multiplexer/multiplexerclient.py
+++ b/lib/clients/Multiplexer/multiplexerclient.py
@@ -72,7 +72,8 @@ class wavemeterclient(QtGui.QWidget):
         screensize = desktop.availableGeometry()
         width = screensize.width()
         height = screensize.height()
-        if (width <=1080 or height <= 1080):
+        min_pixel_size = 1080
+        if (width <= min_pixel_size or height <= min_pixel_size):
             self.showMaximized()
 
     @inlineCallbacks

--- a/lib/clients/Multiplexer/multiplexerclient.py
+++ b/lib/clients/Multiplexer/multiplexerclient.py
@@ -67,14 +67,11 @@ class wavemeterclient(QtGui.QWidget):
         self._check_window_size()
 
     def _check_window_size(self):
-        """Checks from the config file if the window should be resized.
-
-        If the config file does not have the attribute "resize_window", nothing
-        is going to happen so no conflict will be caused.
-        """
-        if hasattr(multiplexer_config, "resize_window"):
-            if multiplexer_config.resize_window is True:
-                self.showMaximized()
+        """Checks screen size to make sure window fits in the screen. """
+        desktop = QtGui.QDesktopWidget()
+        screensize = desktop.availableGeometry()
+        if (screensize[0] or screensize[1]) <= 1080:
+            self.showMaximized()
 
     @inlineCallbacks
     def connect(self):


### PR DESCRIPTION
… for if the client should be maximized upon startup.

Signed-off-by: Xueping Long <gregllong@gmail.com>

The fixed minimum size for the wavemeter client becomes a problem when the client is opened with a netbook. I did a quick and dirty fix to this problem. It does not look too great but I'm able to see all channels on the netbook now.

Please review: @jayich @aransfor @theoriginaljuice 