### PR TITLE
Amj/switch client

### DIFF
--- a/lib/clients/switchclient/switchclient.py
+++ b/lib/clients/switchclient/switchclient.py
@@ -1,42 +1,40 @@
 from common.lib.clients.qtui.switch import QCustomSwitchChannel
 from twisted.internet.defer import inlineCallbacks
 from PyQt4 import QtGui
-#from common.lib.configuration_files.switch_client_config import switch_config
+
 try:
     from config.switch_client_config import switch_config
 except:
     from common.lib.config.switch_client_config import switch_config
 
-class switchclient(QtGui.QWidget):
-    
 
+class switchclient(QtGui.QWidget):
 
     def __init__(self, reactor, cxn=None):
-        """initializels the GUI creates the reactor 
-            and empty dictionary for channel widgets to 
+        """initializels the GUI creates the reactor
+            and empty dictionary for channel widgets to
             be stored for iteration. also grabs chan info
-            from wlm_client_config file 
-        """ 
-            
+            from wlm_client_config file
+        """
         super(switchclient, self).__init__()
         self.setSizePolicy(QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Fixed)
-        self.reactor = reactor    
-	self.cxn = cxn 
-        self.d = {}     
+        self.reactor = reactor
+        self.cxn = cxn
+        self.d = {}
         self.connect()
-        
+
     @inlineCallbacks
     def connect(self):
         """Creates an Asynchronous connection to the wavemeter computer and
         connects incoming signals to relavent functions
-        
+
         """
         from labrad.wrappers import connectAsync
         if self.cxn is None:
             self.cxn = connection("Switch Client")
             yield self.cxn.connect()
-	self.server = yield self.cxn.get_server('arduinottl')
-        self.reg = yield self.cxn.get_server('registry') 
+        self.server = yield self.cxn.get_server('arduinottl')
+        self.reg = yield self.cxn.get_server('registry')
 
         try:
             yield self.reg.cd('settings')
@@ -44,40 +42,40 @@ class switchclient(QtGui.QWidget):
             self.settings = self.settings[1]
         except:
             self.settings = []
-  
-        self.chaninfo = switch_config.info       
+
+        self.chaninfo = switch_config.info
         self.initializeGUI()
-        
+
     @inlineCallbacks
-    def initializeGUI(self):  
-    
+    def initializeGUI(self):
+
         layout = QtGui.QGridLayout()
-        
+
         qBox = QtGui.QGroupBox('Laser Shutters')
         subLayout = QtGui.QGridLayout()
         qBox.setLayout(subLayout)
         layout.addWidget(qBox, 0, 0)
-        
+
         for chan in self.chaninfo:
             port     = self.chaninfo[chan][0]
             position = self.chaninfo[chan][1]
             inverted = self.chaninfo[chan][2]
-            
-            widget = QCustomSwitchChannel(chan,('Closed','Open'))  
+
+            widget = QCustomSwitchChannel(chan, ('Closed', 'Open'))
             if chan + 'shutter' in self.settings:
                 value = yield self.reg.get(chan + 'shutter')
                 widget.TTLswitch.setChecked(value)
             else:
                 widget.TTLswitch.setChecked(False)
-                
-            widget.TTLswitch.toggled.connect(lambda state = widget.TTLswitch.isDown(), port = port, chan = chan, inverted = inverted
-                                               : self.changeState(state, port, chan, inverted))            
+
+            widget.TTLswitch.toggled.connect(lambda state=widget.TTLswitch.isDown(), port=port, chan=chan, inverted=inverted
+                                               : self.changeState(state, port, chan, inverted))
             self.d[port] = widget
             subLayout.addWidget(self.d[port])
-        
+
         self.setLayout(layout)
         yield None
-        
+
     @inlineCallbacks
     def changeState(self, state, port, chan, inverted):
         if inverted:

--- a/lib/clients/switchclient/switchclient.py
+++ b/lib/clients/switchclient/switchclient.py
@@ -31,10 +31,9 @@ class switchclient(QtGui.QWidget):
         """
         from labrad.wrappers import connectAsync
         if self.cxn is None:
-            self.cxn = connection("Switch Client")
-            yield self.cxn.connect()
-        self.server = yield self.cxn.get_server('arduinottl')
-        self.reg = yield self.cxn.get_server('registry')
+            self.cxn = yield connectAsync(name="Switch Client")
+        self.server = yield self.cxn.arduinottl
+        self.reg = yield self.cxn.registry
 
         try:
             yield self.reg.cd('settings')


### PR DESCRIPTION
Reveiw: @gregllong @aransfor 

The name variable change here at least makes sense.  The two shutters on the ion experiment now work with this client.  I don't know why get_server was not working.  I think there was something wrong with cxn.

If someone wants to look into this more carefully, that would be great.  At least for qsim this is working.

Other changes were some pep8 fixes, primarily needed to fix mixed tabs and spaces.