### PR TITLE
mf/188 Adding default andor_config.py

### DIFF
--- a/lib/config/andor_config.py
+++ b/lib/config/andor_config.py
@@ -1,0 +1,13 @@
+class AndorConfig(object):
+    '''
+    path to atmcd64d.dll SDK library
+    '''
+    #default parameters
+    path_to_dll = ('C:\\Program Files\\Andor SOLIS\\atmcd64d_legacy.dll')
+    set_temperature = -20 #degrees C
+    read_mode = 'Image'
+    acquisition_mode = 'Single Scan'
+    trigger_mode = 'Internal'
+    exposure_time = 0.100 #seconds
+    binning = [1, 1] #numbers of pixels for horizontal and vertical binning
+    image_path = ('C:\\Users\\scientist\\Pictures\\iXonImages\\')

--- a/lib/servers/iXonServer/.gitignore
+++ b/lib/servers/iXonServer/.gitignore
@@ -1,1 +1,0 @@
-configuration.py


### PR DESCRIPTION
Add example andor_config.py to common/lib/configs, and delete the .gitignore in the iXonServer folder.