### PR TITLE
Andor server change saving format

### DIFF
--- a/lib/config/andor_config.py
+++ b/lib/config/andor_config.py
@@ -13,4 +13,4 @@ class AndorConfig(object):
     image_path = ('C:\\Users\\scientist\\Pictures\\iXonImages\\')
     save_in_sub_dir = True
     save_format = "tsv"
-    save_metadata = True
+    save_header = True

--- a/lib/config/andor_config.py
+++ b/lib/config/andor_config.py
@@ -11,3 +11,5 @@ class AndorConfig(object):
     exposure_time = 0.100 #seconds
     binning = [1, 1] #numbers of pixels for horizontal and vertical binning
     image_path = ('C:\\Users\\scientist\\Pictures\\iXonImages\\')
+    save_in_sub_dir = True
+    save_format = "tsv"

--- a/lib/config/andor_config.py
+++ b/lib/config/andor_config.py
@@ -13,3 +13,4 @@ class AndorConfig(object):
     image_path = ('C:\\Users\\scientist\\Pictures\\iXonImages\\')
     save_in_sub_dir = True
     save_format = "tsv"
+    save_metadata = True

--- a/lib/servers/iXonServer/AndorVideo.py
+++ b/lib/servers/iXonServer/AndorVideo.py
@@ -268,9 +268,9 @@ class AndorVideo(QtGui.QWidget):
         return dt_str
     
     def str_datetime_to_path(self, str_datetime):
-        year = str_datetime[0] + ".dir"
-        month = str_datetime[1] + ".dir"
-        day = str_datetime[0] + "_" + str_datetime[1] + "_" + str_datetime[2] + ".dir"
+        year = str_datetime[0]
+        month = str_datetime[1]
+        day = year + "_" + month + "_" + str_datetime[2]
         return (year, month, day)
 
     def check_save_path_exists(self):

--- a/lib/servers/iXonServer/AndorVideo.py
+++ b/lib/servers/iXonServer/AndorVideo.py
@@ -1,6 +1,6 @@
 from config.andor_config import andor_config as config
 from PyQt4 import QtGui, QtCore
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet.task import LoopingCall
 import numpy as np
 import pyqtgraph as pg
@@ -228,18 +228,16 @@ class AndorVideo(QtGui.QWidget):
         self.img_view.setImage(image_data.transpose(), autoRange = False, autoLevels = False, pos = [self.startx, self.starty], scale = [self.binx,self.biny], autoHistogramRange = False)
 
         if self.save_images_state == True:
-            yield self.save_image(image_data)
+            self.save_image(image_data)
             
-    @inlineCallbacks
     def get_image_header(self):
         header = ""
-        shutter_time = yield self.server.getExposureTime(None)
-        header += "shutter_time " + str(shutter_time["s"]) + "\n"
-        em_gain = yield self.server.getEMCCDGain(None)
+        shutter_time = self.exposureSpinBox.value()
+        header += "shutter_time " + str(shutter_time) + "\n"
+        em_gain = self.emccdSpinBox.value()
         header += "em_gain " + str(em_gain)
-        returnValue(header)
+        return header
 
-    @inlineCallbacks
     def save_image(self, image_data):
         if not np.array_equal(image_data, self.saved_data):
             self.saved_data = image_data
@@ -251,7 +249,7 @@ class AndorVideo(QtGui.QWidget):
             else:
                 path = os.path.join(self.image_path, time_stamp)
             if self.save_header:
-                header = yield self.get_image_header()
+                header = self.get_image_header()
             else:
                 header = ""
             if self.save_format == "tsv":
@@ -262,7 +260,6 @@ class AndorVideo(QtGui.QWidget):
                 saved_data_in_int.tofile(path + ".dat")
             else:
                 np.savetxt(path + ".tsv", saved_data_in_int, fmt='%i', header=header)
-        yield
 
     def datetime_to_str_list(self):
         dt = datetime.now()

--- a/lib/servers/iXonServer/AndorVideo.py
+++ b/lib/servers/iXonServer/AndorVideo.py
@@ -6,6 +6,7 @@ import numpy as np
 import pyqtgraph as pg
 import datetime as datetime
 from datetime import datetime
+import os
 
 
 class AndorVideo(QtGui.QWidget):
@@ -21,6 +22,17 @@ class AndorVideo(QtGui.QWidget):
 
         self.save_images_state = False
         self.image_path = config.image_path
+
+        try:
+            self.save_in_sub_dir = config.save_in_sub_dir
+        except Exception as e:
+            self.save_in_sub_dir = False
+            print("save_in_sub_dir not found in config")
+        try:
+            self.save_format = config.save_format
+        except Exception as e:
+            self.save_format = "tsv"
+            print("save_format not found in config")
 
 #        emrange= yield self.server.getemrange(None)
 #        self.emccdSpinBox.setMinimum(emrange[0])
@@ -213,10 +225,31 @@ class AndorVideo(QtGui.QWidget):
         if self.save_images_state == True:
             if not np.array_equal(image_data, self.saved_data):
                 self.saved_data = image_data
+                saved_data_in_int = self.saved_data.astype("int16")
                 dt = datetime.now()
                 time_stamp = str(dt.year).rjust(4,"0")+str(dt.month).rjust(2,"0")+str(dt.day).rjust(2,"0")+str(dt.hour).rjust(2,"0")\
-                +str(dt.minute).rjust(2,"0")+str(dt.second).rjust(2,"0")+str(dt.microsecond/1000).rjust(3,"0")+'.csv'
-                np.savetxt(self.image_path+time_stamp,image_data)
+                             +str(dt.minute).rjust(2,"0")+str(dt.second).rjust(2,"0")+str(int(dt.microsecond/1000)).rjust(3,"0")
+                if self.save_in_sub_dir:
+                    path = self.image_path
+                    folder = [str(dt.year).rjust(4,"0"), str(dt.month).rjust(2,"0"), str(dt.day).rjust(2,"0")]
+                    for sub_dir in folder:
+                        path = os.path.join(path, sub_dir)
+                        if not os.path.isdir(path):
+                            os.makedirs(path)
+
+                    path += os.path.join(path, time_stamp)
+                else:
+                    time_stamp = str(dt.year).rjust(4,"0")+str(dt.month).rjust(2,"0")+str(dt.day).rjust(2,"0")+str(dt.hour).rjust(2,"0")\
+                                 +str(dt.minute).rjust(2,"0")+str(dt.second).rjust(2,"0")+str(int(dt.microsecond/1000)).rjust(3,"0")
+                    path = os.path.join(self.image_path, time_stamp)
+                if self.save_format == "tsv":
+                    np.savetxt(path + ".tsv", saved_data_in_int)
+                elif self.save_format == "csv":
+                    np.savetxt(path = ".csv", saved_data_in_int, delimiter=",")
+                elif self.save_format == "bin":
+                    saved_data_in_int.tofile(path + ".dat") 
+                else:
+                    np.savetxt(path + ".tsv", saved_data_in_int)
     
     @inlineCallbacks
     def start_live_display(self):

--- a/lib/servers/iXonServer/AndorVideo.py
+++ b/lib/servers/iXonServer/AndorVideo.py
@@ -223,34 +223,41 @@ class AndorVideo(QtGui.QWidget):
         self.img_view.setImage(image_data.transpose(), autoRange = False, autoLevels = False, pos = [self.startx, self.starty], scale = [self.binx,self.biny], autoHistogramRange = False)
 
         if self.save_images_state == True:
-            if not np.array_equal(image_data, self.saved_data):
-                self.saved_data = image_data
-                saved_data_in_int = self.saved_data.astype("int16")
-                dt = datetime.now()
-                time_stamp = str(dt.year).rjust(4,"0")+str(dt.month).rjust(2,"0")+str(dt.day).rjust(2,"0")+str(dt.hour).rjust(2,"0")\
-                             +str(dt.minute).rjust(2,"0")+str(dt.second).rjust(2,"0")+str(int(dt.microsecond/1000)).rjust(3,"0")
-                if self.save_in_sub_dir:
-                    path = self.image_path
-                    folder = [str(dt.year).rjust(4,"0"), str(dt.month).rjust(2,"0"), str(dt.day).rjust(2,"0")]
-                    for sub_dir in folder:
-                        path = os.path.join(path, sub_dir)
-                        if not os.path.isdir(path):
-                            os.makedirs(path)
+            self.save_image(image_data)
 
-                    path += os.path.join(path, time_stamp)
-                else:
-                    time_stamp = str(dt.year).rjust(4,"0")+str(dt.month).rjust(2,"0")+str(dt.day).rjust(2,"0")+str(dt.hour).rjust(2,"0")\
-                                 +str(dt.minute).rjust(2,"0")+str(dt.second).rjust(2,"0")+str(int(dt.microsecond/1000)).rjust(3,"0")
-                    path = os.path.join(self.image_path, time_stamp)
-                if self.save_format == "tsv":
-                    np.savetxt(path + ".tsv", saved_data_in_int)
-                elif self.save_format == "csv":
-                    np.savetxt(path = ".csv", saved_data_in_int, delimiter=",")
-                elif self.save_format == "bin":
-                    saved_data_in_int.tofile(path + ".dat") 
-                else:
-                    np.savetxt(path + ".tsv", saved_data_in_int)
-    
+    def save_image(self, image_data):
+        if not np.array_equal(image_data, self.saved_data):
+            self.saved_data = image_data
+            saved_data_in_int = self.saved_data.astype("int16")
+            time_stamp = "-".join(self.datetime_to_str_list())
+            if self.save_in_sub_dir:
+                path = self.check_save_path_exists()
+                path = os.path.join(path, time_stamp)
+            else:
+                path = os.path.join(self.image_path, time_stamp)
+            if self.save_format == "tsv":
+                np.savetxt(path + ".tsv", saved_data_in_int)
+            elif self.save_format == "csv":
+                np.savetxt(path = ".csv", saved_data_in_int, delimiter=",")
+            elif self.save_format == "bin":
+                saved_data_in_int.tofile(path + ".dat") 
+            else:
+                np.savetxt(path + ".tsv", saved_data_in_int)
+                
+    def datetime_to_str_list(self):
+        dt = datetime.now()
+        dt_str = [str(dt.year).rjust(4,"0"), str(dt.month).rjust(2,"0"), str(dt.day).rjust(2,"0"), str(dt.hour).rjust(2,"0"),
+                  str(dt.minute).rjust(2,"0"), str(dt.second).rjust(2,"0"), str(int(dt.microsecond/1000)).rjust(3,"0")]
+        return dt_str
+
+    def check_save_path_exists(self):
+        folders = self.datetime_to_str_list()[0:3]
+        for sub_dir in folders:
+            path = os.path.join(self.image_path, sub_dir)
+            if not os.path.isdir(path):
+                os.makedirs(path)
+        return path
+
     @inlineCallbacks
     def start_live_display(self):
         self.live_button.setChecked(True)


### PR DESCRIPTION
Addresses #220.

This PR introduces following changes:
- Config option **save_in_sub_dir**: If enabled. it will save images in dated folders, such as `images_folder/2018/03/2018_03_17`. Default enabled.
- Config option **save_format**: It has three choices: "tsv" will save images as tab separated ascii data files, "csv" will save images as comma separated ascii data files, and "bin" will save images as binary file, with each word (2 bytes) representing a pixel in int16 format. The image file extension will be changed to "csv", "tsv", and "dat" corresponding to the save format chosen. Default is "tsv".
- Config option **save_header**: If enabled, it will save headers containing exposure time and em gain information to the ascii data file ("csv" or "tsv"). It reads exposure time and em gain information from gui. If saved in binary format, **save_header** is ignored. Default is enabled. A example header looks like:
```
# em_gain = 2
# exposure_time = 0.1
123, 124, 125, 162, ... (data)
```
- Data files are now saved in integer formats.