### PR TITLE
shutter switch server and client use signal

### DIFF
--- a/lib/clients/switchclient/switchclient.py
+++ b/lib/clients/switchclient/switchclient.py
@@ -38,7 +38,8 @@ class switchclient(QtGui.QWidget):
         self.reg = yield self.cxn.get_server('registry')
 
         yield self.server.signal__on_switch_changed(self.SIGNALID)
-        yield self.server.addListener(listener = self.signal_switch_changed, source = None, ID = self.SIGNALID)
+        yield self.server.addListener(listener=self.signal_switch_changed,
+                                      source=None, ID=self.SIGNALID)
 
         try:
             yield self.reg.cd(['', 'settings'])

--- a/lib/clients/switchclient/switchclient.py
+++ b/lib/clients/switchclient/switchclient.py
@@ -37,9 +37,8 @@ class switchclient(QtGui.QWidget):
         self.server = yield self.cxn.get_server('arduinottl')
         self.reg = yield self.cxn.get_server('registry')
 
-        self.context = yield self.cxn.context()
-        yield server.signal__on_switch_changed(self.SIGNALID, context = self.context)
-        yield server.addListener(listener = self.signal_switch_changed, source = None, ID = self.SIGNALID, context = self.context)
+        yield self.server.signal__on_switch_changed(self.SIGNALID)
+        yield self.server.addListener(listener = self.signal_switch_changed, source = None, ID = self.SIGNALID)
 
         try:
             yield self.reg.cd(['', 'settings'])
@@ -98,6 +97,7 @@ class switchclient(QtGui.QWidget):
         if port in self.d.keys():
             if chan + 'shutter' in self.settings:
                 yield self.reg.set(chan + 'shutter', state)
+            inverted = self.chaninfo[chan][2]
             if inverted:
                 state = not state
             self.d[port].TTLswitch.setChecked(state)

--- a/lib/clients/switchclient/switchclient.py
+++ b/lib/clients/switchclient/switchclient.py
@@ -9,6 +9,7 @@ except:
 
 
 class switchclient(QtGui.QWidget):
+    SIGNALID = 219749
 
     def __init__(self, reactor, cxn=None):
         """initializes the GUI creates the reactor
@@ -21,6 +22,7 @@ class switchclient(QtGui.QWidget):
         self.reactor = reactor
         self.cxn = cxn
         self.d = {}
+        self.chan_from_port = {}
         self.connect()
 
     @inlineCallbacks
@@ -34,6 +36,10 @@ class switchclient(QtGui.QWidget):
             yield self.cxn.connect()
         self.server = yield self.cxn.get_server('arduinottl')
         self.reg = yield self.cxn.get_server('registry')
+
+        self.context = yield self.cxn.context()
+        yield server.signal__on_switch_changed(self.SIGNALID, context = self.context)
+        yield server.addListener(listener = self.signal_switch_changed, source = None, ID = self.SIGNALID, context = self.context)
 
         try:
             yield self.reg.cd(['', 'settings'])
@@ -71,6 +77,7 @@ class switchclient(QtGui.QWidget):
                                              port=port, chan=chan, inverted=inverted:
                                              self.changeState(state, port, chan, inverted))
             self.d[port] = widget
+            self.chan_from_port[port] = chan
             subLayout.addWidget(self.d[port], position[0], position[1])
 
         self.setLayout(layout)
@@ -82,6 +89,18 @@ class switchclient(QtGui.QWidget):
         if inverted:
             state = not state
         yield self.server.ttl_output(port, state)
+
+    @inlineCallbacks
+    def signal_switch_changed(self, c, signal):
+        port = signal[0]
+        state = signal[1]
+        chan = self.chan_from_port[port]
+        if port in self.d.keys():
+            if chan + 'shutter' in self.settings:
+                yield self.reg.set(chan + 'shutter', state)
+            if inverted:
+                state = not state
+            self.d[port].TTLswitch.setChecked(state)
 
     def closeEvent(self, x):
         self.reactor.stop()

--- a/lib/servers/shutterandswitch/Arduinoshutterandswitchserver.py
+++ b/lib/servers/shutterandswitch/Arduinoshutterandswitchserver.py
@@ -18,7 +18,7 @@ timeout = 20
 
 from labrad.types import Value
 from labrad.devices import DeviceServer, DeviceWrapper
-from labrad.server import setting
+from labrad.server import setting, Signal
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 TIMEOUT = Value(1.0, 's')
@@ -76,6 +76,7 @@ class ArduinoTTL(DeviceServer):
         self.reg = self.client.registry()
         yield self.loadConfigInfo()
         yield DeviceServer.initServer(self)
+        self.listeners = set()
 
     @inlineCallbacks
     def loadConfigInfo(self):
@@ -104,12 +105,24 @@ class ArduinoTTL(DeviceServer):
             devs += [(devName, (server, port))]
         returnValue(devs)
 
+    def initContext(self, c):
+        self.listeners.add(c.ID)
+
+    def expireContext(self, c):
+        self.listeners.remove(c.ID)
+
+    def getOtherListeners(self, c):
+        notified = self.listeners.copy()
+        notified.remove(c.ID)
+        return notified
+
     @setting(100, 'TTL Output', chan='i', state='b')
     def ttlOutput(self, c, chan, state):
         dev = self.selectDevice(c)
         output = (chan << 2) | (state + 2)
         yield dev.write(chr(output))
-        self.notifyOtherListeners(c, (chan, state), self.on_switch_changed)
+        notified = self.getOtherListeners(c)
+        self.on_switch_changed((chan, state), notified)
 
     @setting(200, 'TTL Read', chan='i', returns='b')
     def ttlInput(self, c, chan):

--- a/lib/servers/shutterandswitch/Arduinoshutterandswitchserver.py
+++ b/lib/servers/shutterandswitch/Arduinoshutterandswitchserver.py
@@ -145,6 +145,7 @@ class ArduinoTTL(DeviceServer):
             print status, 'Error Reading'
             returnValue(False)
 
+
 if __name__ == "__main__":
     from labrad import util
     util.runServer(ArduinoTTL())

--- a/lib/servers/shutterandswitch/Arduinoshutterandswitchserver.py
+++ b/lib/servers/shutterandswitch/Arduinoshutterandswitchserver.py
@@ -68,6 +68,8 @@ class ArduinoTTL(DeviceServer):
     deviceName = 'ArduinoTTL'
     deviceWrapper = TTLDevice
 
+    on_switch_changed = Signal(124973, 'signal: on_switch_changed', '(ib)')
+
     @inlineCallbacks
     def initServer(self):
         print 'loading config info...',
@@ -107,6 +109,7 @@ class ArduinoTTL(DeviceServer):
         dev = self.selectDevice(c)
         output = (chan << 2) | (state + 2)
         yield dev.write(chr(output))
+        self.notifyOtherListeners(c, (chan, state), self.on_switch_changed)
 
     @setting(200, 'TTL Read', chan='i', returns='b')
     def ttlInput(self, c, chan):


### PR DESCRIPTION
Addresses #224. This change allows shutter server to update client and registry when switch status is changed.